### PR TITLE
Fix issue #1

### DIFF
--- a/bin_parser.cpp
+++ b/bin_parser.cpp
@@ -86,9 +86,9 @@ int get_bin_data(string inFile, string outFile, stored_vars &v){
                 file.read(reinterpret_cast<char*>(&eh), sizeof(EHEADER));
                 
                 int hits = 0;
-                reset<int16_t>(v.data_type, v);
-                reset<int32_t>(v.LG, v);
-                reset<int32_t>(v.HG, v);
+                reset<int16_t>(v.data_type);
+                reset<int32_t>(v.LG);
+                reset<int32_t>(v.HG);
 
                 // READ EVENT DATA
                 while (file.tellg()<(eh.ev_size+ev_start)){
@@ -120,45 +120,38 @@ int get_bin_data(string inFile, string outFile, stored_vars &v){
                 file.read(reinterpret_cast<char*>(&t_eh), sizeof(T_EHEADER));
 
                 int hits = 0; 
-                reset<int16_t>(v.data_type, v);
-                // reset<float>(v.ToT_timing, v);
-                // reset<float>(v.ToA_timing, v);
-                reset<float>(v.ToT, v);
-                reset<float>(v.ToA, v);
+                reset<int16_t>(v.data_type_timing);
+                reset<float>(v.ToT_timing);
+                reset<float>(v.ToA_timing);
 
                 // READ EVENT DATA
                 while (file.tellg()<(t_eh.ev_size+ev_start)){
                     file.read(reinterpret_cast<char*>(&event), sizeof(EDATA));
 
-                    v.data_type[eh.board_Id][event.ch_ID] = event.data_type;
+                    v.data_type_timing[eh.board_Id][event.ch_ID][hits] = event.data_type;
 
-                    // !! FIX BUG (multiple hits per channel)
                     if(fh.time_unit&0x1){ // times are saved as ns
                         if(event.data_type&0x10){ // ToA saved
                             file.read(reinterpret_cast<char*>(&r.ToA_ns), sizeof(r.ToA_ns));
-                            // v.ToA_timing[t_eh.board_ID][event.ch_ID][0] = r.ToA_ns;
-                            v.ToA[t_eh.board_ID][event.ch_ID] = r.ToA_ns;
-
+                            v.ToA_timing[t_eh.board_ID][event.ch_ID][hits] = r.ToA_ns;
                         }
                         if(event.data_type&0x20){ // ToT saved
                             file.read(reinterpret_cast<char*>(&r.ToT_ns), sizeof(r.ToT_ns));
-                            // v.ToT_timing[t_eh.board_ID][event.ch_ID][0] = r.ToT_ns;
-                            v.ToT[t_eh.board_ID][event.ch_ID] = r.ToT_ns;
+                            v.ToT_timing[t_eh.board_ID][event.ch_ID][hits] = r.ToT_ns;
                         }
                     }
                     else{ // times are saved as LSB
                         if(event.data_type&0x10){ // ToA saved
                             file.read(reinterpret_cast<char*>(&r.ToA_LSB), sizeof(r.ToA_LSB));
-                            // v.ToA_timing[t_eh.board_ID][event.ch_ID][0] = r.ToA_LSB;
-                            v.ToA[t_eh.board_ID][event.ch_ID] = r.ToA_LSB;
+                            v.ToA_timing[t_eh.board_ID][event.ch_ID][hits] = r.ToA_LSB;
                         }
                         if(event.data_type&0x20){ // ToT saved
                             file.read(reinterpret_cast<char*>(&r.ToT_LSB), sizeof(r.ToT_LSB));
-                            // v.ToT_timing[t_eh.board_ID][event.ch_ID][0] = r.ToT_LSB;
-                            v.ToT[t_eh.board_ID][event.ch_ID] = r.ToT_LSB;
+                            v.ToT_timing[t_eh.board_ID][event.ch_ID][hits] = r.ToT_LSB;
                         }
                     }
 
+                    if (hits>=v.hits){cout << "Something went wrong..."<<endl;}
                     hits++;
                 }
 
@@ -176,13 +169,11 @@ int get_bin_data(string inFile, string outFile, stored_vars &v){
                 file.read(reinterpret_cast<char*>(&eh), sizeof(EHEADER));
 
                 int hits = 0;
-                reset<int16_t>(v.data_type, v);
-                reset<int32_t>(v.LG, v);
-                reset<int32_t>(v.HG, v);
-                reset<float>(v.ToT_timing, v);
-                reset<float>(v.ToA_timing, v);
-                reset<float>(v.ToT, v);
-                reset<float>(v.ToA, v);
+                reset<int16_t>(v.data_type);
+                reset<int32_t>(v.LG);
+                reset<int32_t>(v.HG);
+                reset<float>(v.ToT);
+                reset<float>(v.ToA);
 
                 // READ EVENT DATA
                 while (file.tellg()<(eh.ev_size+ev_start)){
@@ -204,25 +195,21 @@ int get_bin_data(string inFile, string outFile, stored_vars &v){
                     if(fh.time_unit&0x1){ // times are saved as ns
                         if(event.data_type&0x10){ // ToA saved
                             file.read(reinterpret_cast<char*>(&r.ToA_ns), sizeof(float));
-                            // v.ToA_timing[eh.board_Id][event.ch_ID][0] = (float)r.ToA_ns;
                             v.ToA[eh.board_Id][event.ch_ID] = (float)r.ToA_ns;
 
                         }
                         if(event.data_type&0x20){ // ToT saved
                             file.read(reinterpret_cast<char*>(&r.ToT_ns), sizeof(float));
-                            // v.ToT_timing[eh.board_Id][event.ch_ID][0] = (float)r.ToT_ns;
                             v.ToT[eh.board_Id][event.ch_ID] = (float)r.ToT_ns;
                         }
                     }
                     else{ // times are saved as LSB
                         if(event.data_type&0x10){ // ToA saved
                             file.read(reinterpret_cast<char*>(&r.ToA_LSB), sizeof(r.ToA_LSB));
-                            // v.ToA_timing[eh.board_Id][event.ch_ID][0] = (float)r.ToA_LSB;
                             v.ToA[eh.board_Id][event.ch_ID] = (float)r.ToA_LSB;
                         }
                         if(event.data_type&0x20){ // ToT saved
                             file.read(reinterpret_cast<char*>(&r.ToT_LSB), sizeof(r.ToT_LSB));
-                            // v.ToT_timing[eh.board_Id][event.ch_ID][0] = (float)r.ToT_LSB;
                             v.ToT[eh.board_Id][event.ch_ID] = (float)r.ToT_LSB;
                         }
                     }
@@ -242,7 +229,7 @@ int get_bin_data(string inFile, string outFile, stored_vars &v){
                 file.read(reinterpret_cast<char*>(&eh), sizeof(EHEADER));
                 // READ EVENT DATA
                 int hits = 0;
-                reset<int64_t>(v.counts, v);
+                reset<int64_t>(v.counts);
 
                 while (file.tellg()<(eh.ev_size+ev_start)){
                     file.read(reinterpret_cast<char*>(&r.ch_ID), sizeof(uint8_t));

--- a/bin_parser.cpp
+++ b/bin_parser.cpp
@@ -62,6 +62,8 @@ int get_bin_data(string inFile, string outFile, stored_vars &v){
     // read file header (exactly the same for each acquisition mode)
     file.read(reinterpret_cast<char*>(&fh), sizeof(FHEADER));
     modes acq_mod = find_mode(fh.acq_mode);
+    if(fh.time_unit&0x1){v.time_unit = "ns";}
+    else {v.time_unit = "LSB";}
 
     // make trees 
     TTree *tr_info = new TTree("info","info");
@@ -112,9 +114,6 @@ int get_bin_data(string inFile, string outFile, stored_vars &v){
             break;
 
         case modes::Timing:
-            if(fh.time_unit&0x1){v.time_unit = "ns";}
-            else {v.time_unit = "LSB";}
-
             while(file.tellg()<file_size){
                 ev_start = file.tellg();
                 // READ EVENT HEADER

--- a/display_data.cpp
+++ b/display_data.cpp
@@ -35,7 +35,7 @@ int display_data(){
     bool masked;
     cin >> masked;
 
-    vector<int> channels = {0};
+    vector<int> channels = {};
 
     TFile * file = new TFile(inFile.c_str(), "read");
     if (!file || file->IsZombie()) {

--- a/main.cpp
+++ b/main.cpp
@@ -7,7 +7,7 @@ using namespace std;
 const char *argp_program_version = "converter 1.0";
 const char *argp_program_bug_address = "<carmen.selicato@cern.ch>";
 static char doc[] = "Code to convert a csv file written by the Janus software to a root file.";
-static char args_doc[] = "inputFile N_boards";
+static char args_doc[] = "inputFile";
 
 static struct argp_option options[] = {
   {"output", 'o', "FILE", 0, "Optional output file name"},
@@ -16,7 +16,6 @@ static struct argp_option options[] = {
 
 struct arguments {
   string inFile;
-  int N_boards=-1;  
   string outFile;
 };
 
@@ -29,13 +28,12 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     case ARGP_KEY_ARG:
       switch (state->arg_num) {
         case 0: arguments->inFile = arg; break;
-        case 1: arguments->N_boards = stoi(arg); break;
         default: return ARGP_ERR_UNKNOWN;
       }
       break;
     case ARGP_KEY_END:
-        if (arguments->inFile.empty() || arguments->N_boards == -1){
-            argp_failure(state, 1, 0, "Missing input file or number of boards. See --help for more information.");
+        if (arguments->inFile.empty()){
+            argp_failure(state, 1, 0, "Missing input file. See --help for more information.");
             exit(ARGP_ERR_UNKNOWN);
         }    
     default: return ARGP_ERR_UNKNOWN;
@@ -66,8 +64,6 @@ int main(int argc, char* argv[]){
     TStopwatch timer;
     timer.Start();
 
-    int max_hits = 100;
-
     struct arguments arguments;
     argp_parse(&argp, argc, argv, 0, 0, &arguments);
 
@@ -82,7 +78,7 @@ int main(int argc, char* argv[]){
     //     cout << endl;
     //     return 1;
     // }
-    stored_vars v(arguments.N_boards, max_hits);
+    stored_vars v;
 
     // process binary files
     if (arguments.inFile.substr(arguments.inFile.size()-4)==".dat") {

--- a/modes_helpers.cpp
+++ b/modes_helpers.cpp
@@ -189,14 +189,14 @@ TTree * make_data_tree(vector<vector<string>>& data, const modes& mode, stored_v
         {
             cout << "Acquisition mode: Spectroscopy." << endl;
 
-            Double_t time = 0;
             reset<int16_t>(v.data_type, v);
             reset<Int_t>(v.LG, v);
             reset<Int_t>(v.HG, v);
 
-            for (vector<string> row : data){
+            for (int i=0; i<data.size(); i++){
+                vector<string> row = data[i];
                 v.Trg_Id = stoi(row[1]);
-                v.TStamp = stold(row[0]);
+                v.TStamp = stod(row[0]);
                 v.hits = stoi(row[3]);
                 v.ch_mask = stoull(row[4], nullptr, 16);
                 
@@ -209,8 +209,12 @@ TTree * make_data_tree(vector<vector<string>>& data, const modes& mode, stored_v
                 v.LG[board][ch_ID] = stoi(row[7]);
                 v.HG[board][ch_ID] = stoi(row[8]);
 
-                if (v.TStamp != time){
-                    time = v.TStamp;
+                if (i==data.size()-1){
+                    t->Fill();
+                    continue;
+                }                
+
+                else if (v.TStamp != stod(data[i+1][0])){
                     t->Fill();
                     reset<int16_t>(v.data_type, v);
                     reset<Int_t>(v.LG, v);
@@ -224,17 +228,17 @@ TTree * make_data_tree(vector<vector<string>>& data, const modes& mode, stored_v
         {
             cout << "Acquisition mode: Spect_Timing." << endl;
 
-            Double_t time = 0;
             reset<int16_t>(v.data_type, v);
             reset<Int_t>(v.LG, v);
             reset<Int_t>(v.HG, v);
             reset<float>(v.ToA, v);
             reset<float>(v.ToT, v);
 
-            for (vector<string> row : data){
+            for (int i=0; i<data.size(); i++){
+                vector<string> row = data[i];
                 v.Trg_Id = stoull(row[1]);
                 v.ch_mask = stoull(row[4], nullptr, 16);
-                v.TStamp = stold(row[0]);
+                v.TStamp = stod(row[0]);
                 v.hits = stoi(row[3]);
 
                 board= stoi(row[2]);
@@ -248,8 +252,12 @@ TTree * make_data_tree(vector<vector<string>>& data, const modes& mode, stored_v
                 v.ToA[board][ch_ID] = stof(row[9]);
                 v.ToT[board][ch_ID] = stof(row[10]);
 
-                if (v.TStamp != time){
-                    time = v.TStamp;
+                if (i==data.size()-1){
+                    t->Fill();
+                    continue;
+                } 
+
+                else if (v.TStamp != stod(data[i+1][0])){
                     t->Fill();
                     reset<int16_t>(v.data_type, v);
                     reset<Int_t>(v.LG, v);
@@ -268,13 +276,13 @@ TTree * make_data_tree(vector<vector<string>>& data, const modes& mode, stored_v
             // the acquistion modes Timing_CStart and Timing_CStop have the same structure
             cout << "The acquisition mode is Timing." << endl;
 
-            Double_t time = 0;
             reset<int16_t>(v.data_type, v);
             reset<float>(v.ToA, v);
             reset<float>(v.ToT, v);
 
-            for (vector<string> row : data){
-                v.TStamp = stold(row[0]);
+            for (int i=0; i<data.size(); i++){
+                vector<string> row = data[i];
+                v.TStamp = stod(row[0]);
                 v.hits = stoi(row[2]);
 
                 board= stoi(row[1]);
@@ -285,9 +293,13 @@ TTree * make_data_tree(vector<vector<string>>& data, const modes& mode, stored_v
                 v.data_type[board][ch_ID] = stoi(row[4], nullptr, 16);
                 v.ToA[board][ch_ID] = stof(row[5]);    
                 v.ToT[board][ch_ID] = stof(row[6]);   
+        
+                if (i==data.size()-1){
+                    t->Fill();
+                    continue;
+                }
 
-                if (v.TStamp != time){
-                    time = v.TStamp;
+                else if (v.TStamp != stod(data[i+1][0])){
                     t->Fill();
                     reset<int16_t>(v.data_type, v);
                     reset<float>(v.ToA, v);
@@ -301,12 +313,12 @@ TTree * make_data_tree(vector<vector<string>>& data, const modes& mode, stored_v
         {
             cout << "The acquisition mode is Counting." << endl;
 
-            uint64_t ID = 0;
             reset<int64_t>(v.counts, v);
 
-            for (vector<string> row : data){
+            for (int i=0; i<data.size(); i++){
+                vector<string> row = data[i];
                 v.Trg_Id = stoull(row[1]);
-                v.TStamp = stold(row[0]);
+                v.TStamp = stod(row[0]);
                 v.ch_mask = stoull(row[4], nullptr, 16);
                 v.hits = stoi(row[3]);
 
@@ -315,8 +327,12 @@ TTree * make_data_tree(vector<vector<string>>& data, const modes& mode, stored_v
                 is_valid_ind(board, ch_ID,N_boards);
                 v.counts[board][ch_ID] = stoi(row[6]);
 
-                if (v.Trg_Id != ID){
-                    ID = v.Trg_Id;
+                if (i==data.size()-1){
+                    t->Fill();
+                    continue;
+                } 
+
+                else if (v.TStamp != stod(data[i+1][0])){
                     t->Fill();
                     reset<int64_t>(v.counts, v);
                 }

--- a/modes_helpers.hpp
+++ b/modes_helpers.hpp
@@ -109,7 +109,7 @@ template<typename T>
 T** reset(T** c, stored_vars& v){
     for (int i = 0; i < v.get_N_boards(); i++) {
         for (int j = 0; j < 64; j++) { // 64 is fixed because it's the number of channels
-            c[i][j] = static_cast<T>(-2);
+            c[i][j] = static_cast<T>(-1);
         }
     }
     return c;
@@ -120,18 +120,17 @@ T*** reset(T*** c, stored_vars& v){
     for (int i = 0; i < v.get_N_boards(); i++) {
         for (int j = 0; j < 64; j++) { // 64 is fixed because it's the number of channels
             for (int k=0; k<v.get_max_hits(); k++){
-                c[i][j][k] = static_cast<T>(-2);
+                c[i][j][k] = static_cast<T>(-1);
             }
         }
     }
     return c;
 }
+
 void is_valid_ind(int board,int ch,int N_boards);
-vector<vector<string>> get_event(vector<vector<string>>& data, unsigned long long& r, unsigned long long& ev_start);
+vector<vector<string>> get_event(vector<vector<string>>& data, unsigned long long r, unsigned long long& ev_start);
 modes find_mode(const TString& str);
 modes find_mode(uint8_t acq_mode);
-// template<typename T> T** reset(T** c, stored_vars& v);
-// template<typename T> T*** reset(T*** c, stored_vars& v);
 TTree * make_branches_info(TTree * t, const modes& mode, stored_vars &v);
 TTree * make_branches_data(TTree * t, const modes& mode, stored_vars &v);
 TTree * make_info_tree(vector<vector<string>>& metadata, const modes& mode, stored_vars &v);


### PR DESCRIPTION
The issue is with the multi-index arrays created as pointers of pointers when the first dimension (number of boards) is greater than 1.  The problem was not detected in the case of a 2D array because the number of boards was always set to 1. If N_boards>=1, only the data relative to the first board (index 0) would be stored in the TTree correctly, while the data of the second one would be corrupted (probable memory leak). 
The issue became evident when trying to implement a 3D array (created as pointers of pointers of pointers): even with the first dimension set to 1, the others were not (number of channels/board and number of hits over time - respectively 64 and 100), which corrupted all the data beyond [0][0][0].

The tree map was defined in a class, where the multidimensional arrays were declared as
```
    int16_t** data_type;
    int32_t** LG;
    int32_t** HG;
    int64_t** counts; // warning: (in principle) there could be loss of data...
    float** ToA;         // does float need to change too?
    float** ToT;
    float*** ToA_timing;
    float*** ToT_timing;
    
    stored_vars(int N_boards_, int max_hits_): N_boards(N_boards_), max_hits(max_hits_)
    {
        data_type = new int16_t*[N_boards];
        LG = new int32_t*[N_boards];
        HG = new int32_t*[N_boards];
        counts = new int64_t*[N_boards];
        ToA = new float*[N_boards];
        ToT = new float*[N_boards];
        ToA_timing = new float**[N_boards];
        ToT_timing = new float**[N_boards];
        
        for (int i = 0; i < N_boards; i++) {
            data_type[i] = new int16_t[64];
            LG[i] = new int32_t[64];
            HG[i] = new int32_t[64];
            counts[i] = new int64_t[64];
            ToA[i] = new float[64];
            ToT[i] = new float[64];

            ToA_timing[i] = new float*[64];
            ToT_timing[i] = new float*[64];

            for (int j = 0; j < 64; j++) {
                ToA_timing[i][j] = new float[max_hits];
                ToT_timing[i][j] = new float[max_hits];

            }
        }

    }
```
The problem stems form the definition of the dimensions of the arrays. The first dimension (N_boards) was at first given as an argument to the executable, while the third dimension (max_hits) was defined in main. As stated above, this corrupted the data. Even defining both N_boards and max_hits in main did not solve the problem. 
The only way to store multidimensional arrays in TTrees is if the dimensions are defined as directives:
```
#define NBOARDS 1
#define NCHANNELS 64
#define MAXHITS 100
```
and in the class the multidimensional arrays are declared as:
```
    float ToA[NBOARDS][NCHANNELS];
    float ToA_timing[NBOARDS][NCHANNELS][MAXHITS];
```

The 3D arrays was also implemented for the data_type in timing mode.